### PR TITLE
fix: modify translation api dto(request, response)

### DIFF
--- a/src/main/java/kr/co/ipalab/lingobe/api/translation/dto/request/TranslationRequestDto.java
+++ b/src/main/java/kr/co/ipalab/lingobe/api/translation/dto/request/TranslationRequestDto.java
@@ -15,5 +15,5 @@ public class TranslationRequestDto {
     private String query;
     private String sourceLan;
     private String targetLan;
-    private Map<String, String> kargs;
+    private Map<String, String> kwargs;
 }

--- a/src/main/java/kr/co/ipalab/lingobe/api/translation/service/TranslationService.java
+++ b/src/main/java/kr/co/ipalab/lingobe/api/translation/service/TranslationService.java
@@ -29,7 +29,7 @@ public class TranslationService {
         try {
             FlaskTranslationResponseDto flaskTranslationResponse = FlaskServerManager.getFlaskResponse(FLASK_TRANSLATION_PATH, HttpMethod.GET, translationRequestDto, FlaskTranslationResponseDto.class);
             return TranslationResponseDto.builder()
-                .translatedResult(flaskTranslationResponse.getQuery())
+                .translatedResult(flaskTranslationResponse.getOutput())
                 .build();
         } catch (Exception e) {
             throw new FlaskResponseTimeoutError();

--- a/src/main/java/kr/co/ipalab/lingobe/flask/translation/dto/request/FlaskTranslationRequestDto.java
+++ b/src/main/java/kr/co/ipalab/lingobe/flask/translation/dto/request/FlaskTranslationRequestDto.java
@@ -15,5 +15,5 @@ public class FlaskTranslationRequestDto {
     private String query;
     private String sourceLan;
     private String targetLan;
-    private Map<String, Object> kargs;
+    private Map<String, Object> kwargs;
 }

--- a/src/main/java/kr/co/ipalab/lingobe/flask/translation/dto/response/FlaskTranslationResponseDto.java
+++ b/src/main/java/kr/co/ipalab/lingobe/flask/translation/dto/response/FlaskTranslationResponseDto.java
@@ -12,5 +12,5 @@ import lombok.Setter;
 @AllArgsConstructor
 public class FlaskTranslationResponseDto {
     private Map<String, Object> score;
-    private String query; // result of translation
+    private String output; // result of translation
 }


### PR DESCRIPTION
- modify request, response to a more intuitive name than before
- modify flask translation request(kargs -> kwargs), response dto(query -> output)
- modify TranslationRequestDto(kargs -> kwargs)
- reflect modifications to service logic

Close #8 